### PR TITLE
Plug leaks with regex handling

### DIFF
--- a/kyua-testers/tap_parser.c
+++ b/kyua-testers/tap_parser.c
@@ -172,7 +172,6 @@ regex_match_to_long(const char* line, const regmatch_t* match, long* output)
 kyua_error_t
 kyua_tap_try_parse_plan(const char* line, kyua_tap_summary_t* summary)
 {
-    kyua_error_t kyua_error;
     int code;
 
     regex_t preg;


### PR DESCRIPTION
There were a number of locations in edgecases where the regular expression object wasn't freed after it was allocated (mostly "short circuit logic" which returned kyua_error_t objects). The attached patch addresses these edgecases.

Sponsored-by: EMC / Isilon Storage Division
