### PR TITLE
Replace use of d_type member of struct dirent with stat()

### DIFF
--- a/testers/fs_test.c
+++ b/testers/fs_test.c
@@ -45,6 +45,7 @@
 #include <atf-c.h>
 
 #include "testers/error.h"
+#include "testers/text.h"
 
 
 static void run_mount_tmpfs(const char*) KYUA_DEFS_NORETURN;
@@ -92,10 +93,17 @@ lookup(const char* dir, const char* name, const int expected_type)
 
     bool found = false;
     struct dirent* dp;
+    struct stat s;
+    char *path = NULL; 
     while (!found && (dp = readdir(dirp)) != NULL) {
-        if (strcmp(dp->d_name, name) == 0 &&
-            dp->d_type == expected_type) {
-            found = true;
+        if (strcmp(dp->d_name, name) == 0) {
+            kyua_text_printf(&path, "%s/%s", dir, name); 
+            if (stat(path, &s) == 0) {
+                if ((s.st_mode & S_IFMT) == expected_type) {
+                    found = true;
+                }
+            }
+            free(path);
         }
     }
     closedir(dirp);
@@ -205,9 +213,9 @@ ATF_TC_WITHOUT_HEAD(cleanup__file);
 ATF_TC_BODY(cleanup__file, tc)
 {
     atf_utils_create_file("root", "%s", "");
-    ATF_REQUIRE(lookup(".", "root", DT_REG));
+    ATF_REQUIRE(lookup(".", "root", S_IFREG));
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_REG));
+    ATF_REQUIRE(!lookup(".", "root", S_IFREG));
 }
 
 
@@ -215,9 +223,9 @@ ATF_TC_WITHOUT_HEAD(cleanup__subdir__empty);
 ATF_TC_BODY(cleanup__subdir__empty, tc)
 {
     ATF_REQUIRE(mkdir("root", 0755) != -1);
-    ATF_REQUIRE(lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -234,9 +242,9 @@ ATF_TC_BODY(cleanup__subdir__files_and_directories, tc)
     ATF_REQUIRE(mkdir("root/dir1/dir2", 0755) != -1);
     atf_utils_create_file("root/dir1/dir2/file", "%s", "");
     ATF_REQUIRE(mkdir("root/dir1/dir3", 0755) != -1);
-    ATF_REQUIRE(lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -251,7 +259,7 @@ ATF_TC_BODY(cleanup__subdir__unprotect_regular, tc)
     ATF_REQUIRE(chmod("root/dir1/dir2", 0000) != -1);
     ATF_REQUIRE(chmod("root/dir1", 0000) != -1);
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -271,7 +279,7 @@ ATF_TC_BODY(cleanup__subdir__unprotect_symlink, tc)
     ATF_REQUIRE(symlink("/bin/ls", "root/dir1/ls") != -1);
     ATF_REQUIRE(chmod("root/dir1", 0555) != -1);
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -282,7 +290,7 @@ ATF_TC_BODY(cleanup__subdir__links, tc)
     ATF_REQUIRE(mkdir("root/dir1", 0755) != -1);
     ATF_REQUIRE(symlink("../../root", "root/dir1/loop") != -1);
     ATF_REQUIRE(symlink("non-existent", "root/missing") != -1);
-    ATF_REQUIRE(lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
     kyua_error_t error = kyua_fs_cleanup("root");
     if (kyua_error_is_set(error)) {
         if (lchmod_fails())
@@ -290,7 +298,7 @@ ATF_TC_BODY(cleanup__subdir__links, tc)
         kyua_error_free(error);
         atf_tc_fail("kyua_fs_cleanup returned an error");
     }
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -306,7 +314,7 @@ ATF_TC_BODY(cleanup__mount_point__simple, tc)
     atf_utils_create_file("root/zz", "%s", "");
     mount_tmpfs("root/dir1");
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -323,7 +331,7 @@ ATF_TC_BODY(cleanup__mount_point__overlayed, tc)
     mount_tmpfs("root/dir1");
     mount_tmpfs("root/dir1");
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -344,7 +352,7 @@ ATF_TC_BODY(cleanup__mount_point__nested, tc)
     mount_tmpfs("root/dir1/dir2/dir4");
     ATF_REQUIRE(mkdir("root/dir1/dir2/not-mount-point", 0755) != -1);
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -361,7 +369,7 @@ ATF_TC_BODY(cleanup__mount_point__links, tc)
     mount_tmpfs("root/dir1");
     ATF_REQUIRE(symlink("../dir3", "root/dir1/link") != -1);
     ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -401,7 +409,7 @@ ATF_TC_BODY(cleanup__mount_point__busy, tc)
         ATF_REQUIRE(waitpid(pid, &status, 0) != -1);
 
         ATF_REQUIRE(!kyua_error_is_set(kyua_fs_cleanup("root")));
-        ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+        ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
     }
 }
 

--- a/utils/fs/operations_test.cpp
+++ b/utils/fs/operations_test.cpp
@@ -78,10 +78,15 @@ lookup(const char* dir, const char* name, const int expected_type)
 
     bool found = false;
     struct dirent* dp;
+    struct stat s;
     while (!found && (dp = readdir(dirp)) != NULL) {
-        if (std::strcmp(dp->d_name, name) == 0 &&
-            dp->d_type == expected_type) {
-            found = true;
+        if (std::strcmp(dp->d_name, name) == 0) {
+            fs::path lookup_path = fs::path(F("%s/%s") % dir % name);
+            if (stat(lookup_path.c_str(), &s) == 0) {
+                if ((s.st_mode & S_IFMT) == expected_type) {
+                    found = true;
+                }
+            }
         }
     }
     ::closedir(dirp);
@@ -276,7 +281,7 @@ ATF_TEST_CASE_WITHOUT_HEAD(mkdir__ok);
 ATF_TEST_CASE_BODY(mkdir__ok)
 {
     fs::mkdir(fs::path("dir"), 0755);
-    ATF_REQUIRE(lookup(".", "dir", DT_DIR));
+    ATF_REQUIRE(lookup(".", "dir", S_IFDIR));
 }
 
 
@@ -289,28 +294,28 @@ ATF_TEST_CASE_BODY(mkdir__enoent)
     } catch (const fs::system_error& e) {
         ATF_REQUIRE_EQ(ENOENT, e.original_errno());
     }
-    ATF_REQUIRE(!lookup(".", "dir1", DT_DIR));
-    ATF_REQUIRE(!lookup(".", "dir2", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "dir1", S_IFDIR));
+    ATF_REQUIRE(!lookup(".", "dir2", S_IFDIR));
 }
 
 
 ATF_TEST_CASE_WITHOUT_HEAD(mkdir_p__one_component);
 ATF_TEST_CASE_BODY(mkdir_p__one_component)
 {
-    ATF_REQUIRE(!lookup(".", "new-dir", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "new-dir", S_IFDIR));
     fs::mkdir_p(fs::path("new-dir"), 0755);
-    ATF_REQUIRE(lookup(".", "new-dir", DT_DIR));
+    ATF_REQUIRE(lookup(".", "new-dir", S_IFDIR));
 }
 
 
 ATF_TEST_CASE_WITHOUT_HEAD(mkdir_p__many_components);
 ATF_TEST_CASE_BODY(mkdir_p__many_components)
 {
-    ATF_REQUIRE(!lookup(".", "a", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "a", S_IFDIR));
     fs::mkdir_p(fs::path("a/b/c"), 0755);
-    ATF_REQUIRE(lookup(".", "a", DT_DIR));
-    ATF_REQUIRE(lookup("a", "b", DT_DIR));
-    ATF_REQUIRE(lookup("a/b", "c", DT_DIR));
+    ATF_REQUIRE(lookup(".", "a", S_IFDIR));
+    ATF_REQUIRE(lookup("a", "b", S_IFDIR));
+    ATF_REQUIRE(lookup("a/b", "c", S_IFDIR));
 }
 
 
@@ -339,11 +344,11 @@ ATF_TEST_CASE_BODY(mkdir_p__eacces)
     } catch (const fs::system_error& e) {
         ATF_REQUIRE_EQ(EACCES, e.original_errno());
     }
-    ATF_REQUIRE(lookup(".", "a", DT_DIR));
-    ATF_REQUIRE(lookup("a", "b", DT_DIR));
-    ATF_REQUIRE(!lookup(".", "c", DT_DIR));
-    ATF_REQUIRE(!lookup("a", "c", DT_DIR));
-    ATF_REQUIRE(!lookup("a/b", "c", DT_DIR));
+    ATF_REQUIRE(lookup(".", "a", S_IFDIR));
+    ATF_REQUIRE(lookup("a", "b", S_IFDIR));
+    ATF_REQUIRE(!lookup(".", "c", S_IFDIR));
+    ATF_REQUIRE(!lookup("a", "c", S_IFDIR));
+    ATF_REQUIRE(!lookup("a/b", "c", S_IFDIR));
 }
 
 
@@ -356,8 +361,8 @@ ATF_TEST_CASE_BODY(mkdtemp)
 
     const std::string dir_template("tempdir.XXXXXX");
     const fs::path tempdir = fs::mkdtemp(dir_template);
-    ATF_REQUIRE(!lookup("tmp", dir_template.c_str(), DT_DIR));
-    ATF_REQUIRE(lookup("tmp", tempdir.leaf_name().c_str(), DT_DIR));
+    ATF_REQUIRE(!lookup("tmp", dir_template.c_str(), S_IFDIR));
+    ATF_REQUIRE(lookup("tmp", tempdir.leaf_name().c_str(), S_IFDIR));
 }
 
 
@@ -370,8 +375,8 @@ ATF_TEST_CASE_BODY(mkstemp)
 
     const std::string file_template("tempfile.XXXXXX");
     const fs::path tempfile = fs::mkstemp(file_template);
-    ATF_REQUIRE(!lookup("tmp", file_template.c_str(), DT_REG));
-    ATF_REQUIRE(lookup("tmp", tempfile.leaf_name().c_str(), DT_REG));
+    ATF_REQUIRE(!lookup("tmp", file_template.c_str(), S_IFREG));
+    ATF_REQUIRE(lookup("tmp", tempfile.leaf_name().c_str(), S_IFREG));
 }
 
 
@@ -379,9 +384,9 @@ ATF_TEST_CASE_WITHOUT_HEAD(rm_r__empty);
 ATF_TEST_CASE_BODY(rm_r__empty)
 {
     fs::mkdir(fs::path("root"), 0755);
-    ATF_REQUIRE(lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
     fs::rm_r(fs::path("root"));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 
@@ -398,9 +403,9 @@ ATF_TEST_CASE_BODY(rm_r__files_and_directories)
     fs::mkdir(fs::path("root/dir1/dir2"), 0755);
     atf::utils::create_file("root/dir1/dir2/file", "");
     fs::mkdir(fs::path("root/dir1/dir3"), 0755);
-    ATF_REQUIRE(lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(lookup(".", "root", S_IFDIR));
     fs::rm_r(fs::path("root"));
-    ATF_REQUIRE(!lookup(".", "root", DT_DIR));
+    ATF_REQUIRE(!lookup(".", "root", S_IFDIR));
 }
 
 


### PR DESCRIPTION
Illumos does not have the d_type member in struct dirent. To be more
portable,

this web page:

http://stackoverflow.com/questions/2197918/cross-platform-way-of-testing-whether-a-file-is-a-directory

recommends converting code like this:

```
if (de->d_type == DT_DIR)
{
   return 0;
}
```

to this:

```
struct stat s; /*include sys/stat.h if necessary */
..
..
stat(de->d_name, &s);
if (s.st_mode & S_IFDIR)
{
    return 0;
}
```
