### PR TITLE
docs: Standardize document description tone

### DIFF
--- a/doc/kyua-about.1.in
+++ b/doc/kyua-about.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua about"
-.Nd Shows detailed authors, license, and version information
+.Nd show detailed authors, license, and version information
 .Sh SYNOPSIS
 .Nm
 .Op Ar authors | license | version

--- a/doc/kyua-config.1.in
+++ b/doc/kyua-config.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua config"
-.Nd Inspects the values of the loaded configuration
+.Nd inspect the values of the loaded configuration
 .Sh SYNOPSIS
 .Nm
 .Op Ar variable1 .. variableN

--- a/doc/kyua-db-exec.1.in
+++ b/doc/kyua-db-exec.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua db-exec"
-.Nd Executes a SQL statement in a results file
+.Nd execute a SQL statement in a results file
 .Sh SYNOPSIS
 .Nm
 .Op Fl -no-headers

--- a/doc/kyua-db-migrate.1.in
+++ b/doc/kyua-db-migrate.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua db-migrate"
-.Nd Upgrades the schema of an existing results file
+.Nd upgrade the schema of an existing results file
 .Sh SYNOPSIS
 .Nm
 .Op Fl -results-file Ar file

--- a/doc/kyua-debug.1.in
+++ b/doc/kyua-debug.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua debug"
-.Nd Executes a single test case with facilities for debugging
+.Nd execute a single test case with facilities for debugging
 .Sh SYNOPSIS
 .Nm
 .Op Fl -build-root Ar path

--- a/doc/kyua-help.1.in
+++ b/doc/kyua-help.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua help"
-.Nd Shows usage information
+.Nd show usage information
 .Sh SYNOPSIS
 .Nm
 .Op Ar command

--- a/doc/kyua-list.1.in
+++ b/doc/kyua-list.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua list"
-.Nd Lists test cases and their metadata
+.Nd list test cases and their metadata
 .Sh SYNOPSIS
 .Nm
 .Op Fl -build-root Ar path

--- a/doc/kyua-report-html.1.in
+++ b/doc/kyua-report-html.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua report-html"
-.Nd Generates an HTML report with the results of a test suite run
+.Nd generate an HTML report with the results of a test suite run
 .Sh SYNOPSIS
 .Nm
 .Op Fl -force

--- a/doc/kyua-report-junit.1.in
+++ b/doc/kyua-report-junit.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua report-junit"
-.Nd Generates a JUnit report with the results of a test suite run
+.Nd generate a JUnit report with the results of a test suite run
 .Sh SYNOPSIS
 .Nm
 .Op Fl -output Ar path

--- a/doc/kyua-report.1.in
+++ b/doc/kyua-report.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua report"
-.Nd Generates reports with the results of a test suite run
+.Nd generate reports with the results of a test suite run
 .Sh SYNOPSIS
 .Nm
 .Op Fl -output Ar path

--- a/doc/kyua-test.1.in
+++ b/doc/kyua-test.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm "kyua test"
-.Nd Runs tests
+.Nd run tests
 .Sh SYNOPSIS
 .Nm
 .Op Fl -build-root Ar path

--- a/doc/kyua.1.in
+++ b/doc/kyua.1.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm kyua
-.Nd Testing framework for infrastructure software
+.Nd testing framework for infrastructure software
 .Sh SYNOPSIS
 .Nm
 .Op Fl -config Ar file

--- a/doc/kyua.conf.5.in
+++ b/doc/kyua.conf.5.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm kyua.conf
-.Nd Configuration file for the kyua tool
+.Nd configuration file for the kyua tool
 .Sh SYNOPSIS
 .Fn syntax "int version"
 .Pp

--- a/doc/kyuafile.5.in
+++ b/doc/kyuafile.5.in
@@ -30,7 +30,7 @@
 .Os
 .Sh NAME
 .Nm Kyuafile
-.Nd Test suite description files
+.Nd test suite description files
 .Sh SYNOPSIS
 .Fn atf_test_program "string name" "[string metadata]"
 .Fn current_kyuafile


### PR DESCRIPTION
BSD manpages document descriptions should be in the imperative tone, starting with a lowercase letter. This is a trivial editorial nit, so I did not bump the dates.