### PR TITLE
utils/text/regex.hpp: #include <string> for std::string

### DIFF
--- a/utils/text/regex.hpp
+++ b/utils/text/regex.hpp
@@ -36,6 +36,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 
 
 namespace utils {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/976938