### PR TITLE
Preserve pointer provenance when adjusting const

### DIFF
--- a/utils/defs.hpp.in
+++ b/utils/defs.hpp.in
@@ -51,7 +51,7 @@
 ///
 /// \param type The target type of the conversion.
 /// \param ptr The pointer to be unconstified.
-#define UTILS_UNCONST(type, ptr) ((type*)(unsigned long)(const void*)(ptr))
+#define UTILS_UNCONST(type, ptr) ((type*)(uintptr_t)(const void*)(ptr))
 
 
 #endif  // !defined(UTILS_DEFS_HPP)

--- a/utils/process/operations.cpp
+++ b/utils/process/operations.cpp
@@ -164,7 +164,7 @@ process::exec_unsafe(const fs::path& program, const args_vector& args)
         argv[1 + args.size()] = NULL;
 
         const int ret = ::execv(program.c_str(),
-                                (char* const*)(unsigned long)(const void*)argv);
+                                (char* const*)(uintptr_t)(const void*)argv);
         original_errno = errno;
         INV(ret == -1);
         std::cerr << "Failed to execute " << program << ": "


### PR DESCRIPTION
Use uintptr_t instead of unsigned long when tweaking the constness of execv's arguments.  The latter does not preserve provenance while uintptr_t does.

Effort:		CHERI upstreaming
Sponsored by:	Innovate UK